### PR TITLE
docs: update container image references and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Version test
 
 [//]: # (x-release-please-start-version)
 
-* Full Release: 2.1.0
+* Full Release: 2.1.1
 
 ```bash
 cat << EOF
-* Full Release: 2.1.0
+* Full Release: 2.1.1
 EOF
 ```
 
@@ -93,19 +93,19 @@ echo "Test: $(date +'%F')"
 
 <!-- x-release-please-start-version -->
 ```bash
-kubectl run demo-app --image=quay.io/petr_ruzicka/demo-container:2.1.0
+kubectl run demo-app --image=quay.io/petr_ruzicka/malware-cryptominer-container:2.1.1
 ```
 <!-- x-release-please-end -->
 
 <!-- x-release-please-start-major -->
 ```bash
-kubectl run demo-app --image=quay.io/petr_ruzicka/demo-container:2
+kubectl run demo-app --image=quay.io/petr_ruzicka/malware-cryptominer-container:2
 ```
 <!-- x-release-please-end -->
 
 <!-- x-release-please-start-minor -->
 ```bash
-kubectl run demo-app --image=quay.io/petr_ruzicka/demo-container:1.1
+kubectl run demo-app --image=quay.io/petr_ruzicka/malware-cryptominer-container:1.1
 ```
 <!-- x-release-please-end -->
 
@@ -114,7 +114,7 @@ kubectl run demo-app --image=quay.io/petr_ruzicka/demo-container:1.1
 ---
 
 * Container Image:
-  * [quay.io/petr_ruzicka/demo-container:2.0.0](https://quay.io/petr_ruzicka/demo-container:2.0.0)
+  * [quay.io/petr_ruzicka/malware-cryptominer-container:2.0.0](https://quay.io/petr_ruzicka/malware-cryptominer-container:2.0.0)
 
 <!-- x-release-please-start-version -->
 
@@ -123,7 +123,7 @@ export AWS_DEFAULT_REGION="eu-central-1"
 
 aws cloudformation deploy --capabilities CAPABILITY_IAM \
   --stack-name "${USER}-demo-container-ec2" \
-  --parameter-overrides "ContainerImage=quay.io/petr_ruzicka/demo-container:2.1.0" \
+  --parameter-overrides "ContainerImage=quay.io/petr_ruzicka/malware-cryptominer-container:2.1.1" \
   --template-file EC2InstanceWithDockerSample.yaml \
   --tags "Name=${USER}-demo-container-ec2"
 
@@ -139,7 +139,7 @@ export AWS_DEFAULT_REGION="eu-central-2"
 
 aws cloudformation deploy --capabilities CAPABILITY_IAM \
   --stack-name "${USER}-demo-container-ec2" \
-  --parameter-overrides "ContainerImage=quay.io/petr_ruzicka/demo-container:2" \
+  --parameter-overrides "ContainerImage=quay.io/petr_ruzicka/malware-cryptominer-container:2" \
   --template-file EC2InstanceWithDockerSample.yaml \
   --tags "Name=${USER}-demo-container-ec2"
 
@@ -153,11 +153,11 @@ Run in Kubernetes:
 <!-- x-release-please-start-version -->
 
 ```bash
-# Test release: 2.1.0
+# Test release: 2.1.1
 # Test release: 1.1
 # Test release: 1
 
-kubectl run demo-app --image=quay.io/petr_ruzicka/demo-container:2.1.0
+kubectl run demo-app --image=quay.io/petr_ruzicka/malware-cryptominer-container:2.1.1
 ```
 
 <!-- x-release-please-end -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Commit Check](https://github.com/ruzickap/gha-test/actions/workflows/commit-check.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/commit-check.yml)
 [![MegaLinter](https://github.com/ruzickap/gha-test/actions/workflows/mega-linter.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/mega-linter.yml)
 [![Release Please](https://github.com/ruzickap/gha-test/actions/workflows/release-please.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/release-please.yml)
-[![Renovate](https://github.com/ruzickap/gha-test/actions/workflows/renovate.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/renovate.yml)
 [![Scorecards](https://github.com/ruzickap/gha-test/actions/workflows/scorecards.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/scorecards.yml)
 [![Semantic Pull Request](https://github.com/ruzickap/gha-test/actions/workflows/semantic-pull-request.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/semantic-pull-request.yml)
 [![Stale](https://github.com/ruzickap/gha-test/actions/workflows/stale.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/stale.yml)


### PR DESCRIPTION
## Description

Updates the README documentation to reference the
`malware-cryptominer-container` image instead of `demo-container`, and
bumps the release version from `2.1.0` to `2.1.1`.

## Changes

- Replace `quay.io/petr_ruzicka/demo-container` with
  `quay.io/petr_ruzicka/malware-cryptominer-container` across all
  examples (`kubectl run`, CloudFormation `--parameter-overrides`)
- Bump release version from `2.1.0` to `2.1.1` in the
  release-please managed blocks
- Remove the stale Renovate workflow status badge (the `renovate.yml`
  workflow was removed previously, so the badge returned a 404 and
  failed the lychee link check)

## Motivation

Keep the documentation examples aligned with the correct container
image name and the latest release version.

## Notes

Recreated from #5 to rename the branch from `docs/` to `chore/`, as the
`commit-check` action only allows Conventional Branch types
(`feature`, `bugfix`, `hotfix`, `release`, `chore`).