### PR TITLE
docs: remove semantic-pull-request badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![MegaLinter](https://github.com/ruzickap/gha-test/actions/workflows/mega-linter.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/mega-linter.yml)
 [![Release Please](https://github.com/ruzickap/gha-test/actions/workflows/release-please.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/release-please.yml)
 [![Scorecards](https://github.com/ruzickap/gha-test/actions/workflows/scorecards.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/scorecards.yml)
-[![Semantic Pull Request](https://github.com/ruzickap/gha-test/actions/workflows/semantic-pull-request.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/semantic-pull-request.yml)
 [![Stale](https://github.com/ruzickap/gha-test/actions/workflows/stale.yml/badge.svg)](https://github.com/ruzickap/gha-test/actions/workflows/stale.yml)
 
 GitHub Action test repository...


### PR DESCRIPTION
The `semantic-pull-request` workflow is no longer used and `.github/workflows/semantic-pull-request.yml` no longer exists in this repo, so this badge renders permanently broken.

Removes the stale badge from the README badge block. No other references to `semantic-pull-request` remain in this repo (verified with a full-tree grep).

Note: PR title / commit message validation is still covered by `commit-check.yml`, which is unaffected.