### PR TITLE
ci: use native egress firewall runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+---
+self-hosted-runner:
+  labels:
+    - ubuntu-24.04-firewall

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ permissions: read-all
 
 jobs:
   codeql:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     permissions:
       contents: read

--- a/.github/workflows/env-check.yml
+++ b/.github/workflows/env-check.yml
@@ -67,7 +67,7 @@ jobs:
           lshw
 
   ubuntu-colors:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     steps:
       - name: Install kubecolor

--- a/.github/workflows/mega-linter-all.yml
+++ b/.github/workflows/mega-linter-all.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   # Default MegaLinter (all linters)
   mega-linter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter
@@ -24,7 +24,7 @@ jobs:
 
   # Optimized for pure C/C++ projects
   mega-linter-c_cpp:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter c_cpp
@@ -35,7 +35,7 @@ jobs:
 
   # Optimized for CI items (Dockerfile, Jenkinsfile, JSON/YAML schemas, XML)
   mega-linter-ci_light:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter ci_light
@@ -46,7 +46,7 @@ jobs:
 
   # MegaLinter for the most commonly used languages
   mega-linter-cupcake:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter cupcake
@@ -57,7 +57,7 @@ jobs:
 
   # MegaLinter for documentation projects
   mega-linter-documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter documentation
@@ -68,7 +68,7 @@ jobs:
 
   # Optimized for C, C++, C# or VB based projects
   mega-linter-dotnet:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter dotnet
@@ -79,7 +79,7 @@ jobs:
 
   # Optimized for C, C++, C# or VB based projects with JS/TS
   mega-linter-dotnetweb:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter dotnetweb
@@ -90,7 +90,7 @@ jobs:
 
   # Contains only formatters
   mega-linter-formatters:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter formatters
@@ -101,7 +101,7 @@ jobs:
 
   # Optimized for GO based projects
   mega-linter-go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter go
@@ -112,7 +112,7 @@ jobs:
 
   # Optimized for JAVA based projects
   mega-linter-java:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter java
@@ -123,7 +123,7 @@ jobs:
 
   # Optimized for JAVASCRIPT or TYPESCRIPT based projects
   mega-linter-javascript:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter javascript
@@ -134,7 +134,7 @@ jobs:
 
   # Optimized for PHP based projects
   mega-linter-php:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter php
@@ -145,7 +145,7 @@ jobs:
 
   # Optimized for PYTHON based projects
   mega-linter-python:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter python
@@ -156,7 +156,7 @@ jobs:
 
   # Optimized for RUBY based projects
   mega-linter-ruby:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter ruby
@@ -167,7 +167,7 @@ jobs:
 
   # Optimized for RUST based projects
   mega-linter-rust:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter rust
@@ -178,7 +178,7 @@ jobs:
 
   # Optimized for Salesforce based projects
   mega-linter-salesforce:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter salesforce
@@ -189,7 +189,7 @@ jobs:
 
   # Optimized for security
   mega-linter-security:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter security
@@ -200,7 +200,7 @@ jobs:
 
   # Optimized for SWIFT based projects
   mega-linter-swift:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter swift
@@ -211,7 +211,7 @@ jobs:
 
   # Optimized for TERRAFORM based projects
   mega-linter-terraform:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: 💡 MegaLinter terraform

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -14,7 +14,7 @@ permissions: read-all
 
 jobs:
   mega-linter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     if: ${{ (!startsWith(github.ref_name, 'chore/renovate/') && !startsWith(github.ref_name, 'release-please--')) || github.event_name == 'workflow_dispatch' }}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   pr-size-labeler:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-slack-notification.yml
+++ b/.github/workflows/pr-slack-notification.yml
@@ -31,7 +31,7 @@ defaults:
 
 jobs:
   pr-slack-notification:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     if: (github.event.action == 'opened' && github.event.pull_request.draft == false) || github.event.action == 'ready_for_review'
     steps:
@@ -58,7 +58,7 @@ jobs:
           key: slack-message-timestamp-${{ github.event.pull_request.html_url }}-${{ steps.message.outputs.ts }}
 
   slack-emoji-react:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     name: Adds emoji reaction to slack message when a PR is closed or reviewed
     if: ${{ startsWith(github.event.pull_request.html_url, 'https') || startsWith(github.event.issue.pull_request.html_url, 'https') }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   scorecards:
     # ossf/scorecard-action doesn't support arm64
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     permissions:
       # Required for uploading SARIF results to GitHub Security tab

--- a/.github/workflows/setup-docker-action.yml
+++ b/.github/workflows/setup-docker-action.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   setup-docker-action:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 5
     steps:
       - name: Set up Docker

--- a/.github/workflows/virt-check.yml
+++ b/.github/workflows/virt-check.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 jobs:
   virt-check-ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-firewall
     timeout-minutes: 30
     steps:
       - name: Commands


### PR DESCRIPTION
## Summary

- replace `ubuntu-latest` with `ubuntu-24.04-firewall`
- configure actionlint to recognize the early-access runner label

## Validation

- `actionlint`
- `git diff --check`

## Details

https://github.com/github-early-access/actions-native-egress-firewall